### PR TITLE
BUG: JS error if user sets theme to empty string

### DIFF
--- a/src/javascripts/jquery.selectBoxIt.core.js
+++ b/src/javascripts/jquery.selectBoxIt.core.js
@@ -1306,22 +1306,38 @@
 
             var self = this,
 
-                focusClass = obj.focusClasses || "selectboxit-focus",
+                classObj = obj || {
 
-                hoverClass = obj.hoverClasses || "selectboxit-hover",
+                    focusClasses: "active",
 
-                buttonClass = obj.buttonClasses || "selectboxit-btn",
+                    hoverClasses: "jsHover",
 
-                listClass = obj.listClasses || "selectboxit-dropdown";
+                    arrowClasses: "caret",
+
+                    buttonClasses: "sBoxBtn",
+
+                    listClasses: "dropdown-menu",
+
+                    containerClasses: "sBoxCustomTheme"
+
+                },
+
+                focusClass = classObj.focusClasses || "selectboxit-focus",
+
+                hoverClass = classObj.hoverClasses || "selectboxit-hover",
+
+                buttonClass = classObj.buttonClasses || "selectboxit-btn",
+
+                listClass = classObj.listClasses || "selectboxit-dropdown";
 
             self.focusClass = focusClass;
 
             self.selectedClass = "selectboxit-selected";
 
-            self.downArrow.addClass(self.selectBox.data("downarrow") || self.options["downArrowIcon"] || obj.arrowClasses);
+            self.downArrow.addClass(self.selectBox.data("downarrow") || self.options["downArrowIcon"] || classObj.arrowClasses);
 
             // Adds the correct container class to the dropdown list
-            self.dropdownContainer.addClass(obj.containerClasses);
+            self.dropdownContainer.addClass(classObj.containerClasses);
 
             // Adds the correct class to the dropdown list
             self.dropdown.addClass(buttonClass);

--- a/src/javascripts/jquery.selectBoxIt.js
+++ b/src/javascripts/jquery.selectBoxIt.js
@@ -1306,22 +1306,38 @@
 
             var self = this,
 
-                focusClass = obj.focusClasses || "selectboxit-focus",
+                classObj = obj || {
 
-                hoverClass = obj.hoverClasses || "selectboxit-hover",
+                    focusClasses: "active",
 
-                buttonClass = obj.buttonClasses || "selectboxit-btn",
+                    hoverClasses: "jsHover",
 
-                listClass = obj.listClasses || "selectboxit-dropdown";
+                    arrowClasses: "caret",
+
+                    buttonClasses: "sBoxBtn",
+
+                    listClasses: "dropdown-menu",
+
+                    containerClasses: "sBoxCustomTheme"
+
+                },
+
+                focusClass = classObj.focusClasses || "selectboxit-focus",
+
+                hoverClass = classObj.hoverClasses || "selectboxit-hover",
+
+                buttonClass = classObj.buttonClasses || "selectboxit-btn",
+
+                listClass = classObj.listClasses || "selectboxit-dropdown";
 
             self.focusClass = focusClass;
 
             self.selectedClass = "selectboxit-selected";
 
-            self.downArrow.addClass(self.selectBox.data("downarrow") || self.options["downArrowIcon"] || obj.arrowClasses);
+            self.downArrow.addClass(self.selectBox.data("downarrow") || self.options["downArrowIcon"] || classObj.arrowClasses);
 
             // Adds the correct container class to the dropdown list
-            self.dropdownContainer.addClass(obj.containerClasses);
+            self.dropdownContainer.addClass(classObj.containerClasses);
 
             // Adds the correct class to the dropdown list
             self.dropdown.addClass(buttonClass);


### PR DESCRIPTION
or something other than one of the library choices

The attached code resolves the issue by creating an object 
if it is undefined in the _addClass function.

selectBoxIt.js defaults to "bootstrap" if you don't set a
theme, and if you leave the theme option empty or try to
set it to "none" it crashes when trying to go through
_addClasses.  Looks like there is no default object that
_addClasses should consume if a user doesn't use one of
the framework theme option.

I'll leave the question about whether it should be
defaulting to no theme rather than "bootstrap" to you,
but there needs to be a fallback "obj" object
created if _addClass() is called without an obj as in the
else case when setting the theme.
