### PR TITLE
add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "grunt-contrib-jshint": "~0.3.0",
     "grunt-contrib-jasmine": "~0.4.2"
   },
+  "main": "src/javascripts/jquery.selectBoxIt.js",
   "scripts": {
     "test": "grunt travis --verbose"
   },


### PR DESCRIPTION
The package.json file is missing a main attribute.  Without this the module cannot be required by node.js or, more importantly, browserify.
