### PR TITLE
Adding 'main'-entry to package.json for webpack2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "type": "git",
     "url": "git://github.com/gfranko/jQuery.selectBoxIt.js.git"
   },
+  "main": "src/javascripts/jquery.selectBoxIt.js",
   "bugs": {
     "url": "https://github.com/gfranko/jQuery.selectBoxIt.js/issues"
   },


### PR DESCRIPTION
Webpack2 (and maybe others) search automatically for a "main"-key in `package.json` for bundling necessary javascripts. 